### PR TITLE
Build Odoo 17 sales analysis dashboard

### DIFF
--- a/sales_analysis_dashboard/README.md
+++ b/sales_analysis_dashboard/README.md
@@ -1,0 +1,20 @@
+# Sales Analysis Dashboard (Odoo 17)
+
+Preconfigured dashboard on `sale.report` with pivot and graph views, grouped by date, salesperson, team, and more.
+
+## Features
+- Pivot and graph analysis on `sale.report`
+- Quick filters: last 7/30 days, this month; state filters
+- Group by: month, salesperson, team, customer, product, category, country
+- One-click access via the "Sales Analysis" menu
+
+## Installation
+1. Copy `sales_analysis_dashboard` to your addons path.
+2. Update Apps list and install "Sales Analysis Dashboard".
+
+## Usage
+- Open Sales Analysis from the main menu
+- Use pivot/graph toggle, filters, and group by options to explore data
+
+## Uninstall
+- Safe to uninstall (no models or data are permanently modified)

--- a/sales_analysis_dashboard/__manifest__.py
+++ b/sales_analysis_dashboard/__manifest__.py
@@ -1,0 +1,17 @@
+{
+    'name': 'Sales Analysis Dashboard',
+    'summary': 'Preconfigured sales analysis dashboard with pivot, graph, and filters for Odoo 17',
+    'version': '17.0.1.0.0',
+    'category': 'Sales',
+    'license': 'LGPL-3',
+    'author': 'Your Company',
+    'website': 'https://example.com',
+    'depends': ['sale', 'web'],
+    'data': [
+        'views/sales_dashboard_menu.xml',
+        'views/sale_report_views.xml',
+        'data/ir_filters.xml',
+    ],
+    'installable': True,
+    'application': False,
+}

--- a/sales_analysis_dashboard/data/ir_filters.xml
+++ b/sales_analysis_dashboard/data/ir_filters.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Optional saved filters can be added here. Keeping empty to avoid installation issues. -->
+</odoo>

--- a/sales_analysis_dashboard/views/sale_report_views.xml
+++ b/sales_analysis_dashboard/views/sale_report_views.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <!-- Graph View -->
+    <record id="sale_report_view_graph_dashboard" model="ir.ui.view">
+        <field name="name">sale.report.graph.sales.dashboard</field>
+        <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <graph string="Sales" type="bar" stacked="True">
+                <field name="date_order" interval="month" type="row"/>
+                <field name="price_total" type="measure"/>
+                <field name="product_uom_qty" type="measure"/>
+            </graph>
+        </field>
+    </record>
+
+    <!-- Pivot View -->
+    <record id="sale_report_view_pivot_dashboard" model="ir.ui.view">
+        <field name="name">sale.report.pivot.sales.dashboard</field>
+        <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <pivot string="Sales Analysis" disable_linking="0">
+                <field name="date_order" interval="month" type="row"/>
+                <field name="team_id" type="col"/>
+                <field name="user_id" type="col"/>
+                <field name="price_total" type="measure"/>
+                <field name="product_uom_qty" type="measure"/>
+            </pivot>
+        </field>
+    </record>
+
+    <!-- Search View -->
+    <record id="sale_report_view_search_dashboard" model="ir.ui.view">
+        <field name="name">sale.report.search.sales.dashboard</field>
+        <field name="model">sale.report</field>
+        <field name="arch" type="xml">
+            <search string="Search Sales">
+                <filter name="last_7days" string="Last 7 Days" domain="[('date_order','&gt;=', (context_today()-relativedelta(days=7)).strftime('%%Y-%%m-%%d 00:00:00'))]"/>
+                <filter name="last_30days" string="Last 30 Days" domain="[('date_order','&gt;=', (context_today()-relativedelta(days=30)).strftime('%%Y-%%m-%%d 00:00:00'))]"/>
+                <filter name="this_month" string="This Month" domain="[('date_order','&gt;=', context_today().replace(day=1).strftime('%%Y-%%m-%%d 00:00:00'))]"/>
+
+                <separator/>
+                <filter string="Confirmed/Done" name="state_confirmed" domain="[('state','in',('sale','done'))]"/>
+                <filter string="Quotation" name="state_quotation" domain="[('state','in',('draft','sent'))]"/>
+                <filter string="Cancelled" name="state_cancel" domain="[('state','=','cancel')]"/>
+
+                <separator/>
+                <group expand="0" string="Group By">
+                    <filter string="Order Date" name="grp_date" context="{'group_by':'date_order'}"/>
+                    <filter string="Month" name="grp_month" context="{'group_by':'date_order:month'}"/>
+                    <filter string="Salesperson" name="grp_user" context="{'group_by':'user_id'}"/>
+                    <filter string="Sales Team" name="grp_team" context="{'group_by':'team_id'}"/>
+                    <filter string="Customer" name="grp_partner" context="{'group_by':'commercial_partner_id'}"/>
+                    <filter string="Country" name="grp_country" context="{'group_by':'country_id'}"/>
+                    <filter string="Product" name="grp_product" context="{'group_by':'product_tmpl_id'}"/>
+                    <filter string="Category" name="grp_category" context="{'group_by':'categ_id'}"/>
+                </group>
+
+                <field name="company_id" filter_domain="[]"/>
+                <field name="user_id"/>
+                <field name="team_id"/>
+                <field name="commercial_partner_id"/>
+                <field name="country_id"/>
+                <field name="product_tmpl_id"/>
+                <field name="categ_id"/>
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/sales_analysis_dashboard/views/sales_dashboard_menu.xml
+++ b/sales_analysis_dashboard/views/sales_dashboard_menu.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="action_sales_analysis_dashboard" model="ir.actions.act_window">
+        <field name="name">Sales Analysis Dashboard</field>
+        <field name="res_model">sale.report</field>
+        <field name="view_mode">pivot,graph,list</field>
+        <field name="target">current</field>
+        <field name="search_view_id" ref="sales_analysis_dashboard.sale_report_view_search_dashboard"/>
+        <field name="context">{
+            'search_default_last_30days': 1,
+            'graph_mode': 'bar',
+            'graph_measure': 'price_total',
+            'graph_groupby': 'date_order:month'
+        }</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">Start exploring your sales performance</p>
+            <p>Use the filters to narrow down by period, salesperson, team, product, and more.</p>
+        </field>
+    </record>
+
+    <!-- Attach our custom views to the action -->
+    <record id="action_sales_analysis_dashboard_view_pivot" model="ir.actions.act_window.view">
+        <field name="sequence">1</field>
+        <field name="view_mode">pivot</field>
+        <field name="view_id" ref="sales_analysis_dashboard.sale_report_view_pivot_dashboard"/>
+        <field name="act_window_id" ref="sales_analysis_dashboard.action_sales_analysis_dashboard"/>
+    </record>
+    <record id="action_sales_analysis_dashboard_view_graph" model="ir.actions.act_window.view">
+        <field name="sequence">2</field>
+        <field name="view_mode">graph</field>
+        <field name="view_id" ref="sales_analysis_dashboard.sale_report_view_graph_dashboard"/>
+        <field name="act_window_id" ref="sales_analysis_dashboard.action_sales_analysis_dashboard"/>
+    </record>
+
+    <menuitem id="menu_sales_analysis_root"
+              name="Sales Analysis"
+              action="action_sales_analysis_dashboard"
+              sequence="35"/>
+</odoo>


### PR DESCRIPTION
Adds a new Odoo 17 module `sales_analysis_dashboard` to provide a pre-configured sales analysis dashboard on `sale.report`.

---
<a href="https://cursor.com/background-agent?bcId=bc-cafd1bfa-def6-40ad-8223-d75ee7d7afc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cafd1bfa-def6-40ad-8223-d75ee7d7afc1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

